### PR TITLE
ESP8266 compatibility

### DIFF
--- a/RadiationWatch.cpp
+++ b/RadiationWatch.cpp
@@ -13,7 +13,7 @@
  * Yoan Tournade <yoan@ytotech.com>
  */
 #include "RadiationWatch.h"
-#ifndef ARDUINO_ARCH_AVR
+#if !defined(ARDUINO_ARCH_AVR) && !defined(ESP8266)
 #include <avr/dtostrf.h>
 #endif
 


### PR DESCRIPTION
Hi,
thank you for the Arduino library for the PocketGeiger. It is very useful especially the use of interrupts is the right  way!

This patch makes the library compatible to the ESP8266 boards.