### PR TITLE
API changes

### DIFF
--- a/RadiationWatch.cpp
+++ b/RadiationWatch.cpp
@@ -132,6 +132,12 @@ char* RadiationWatch::csvStatus()
   return _msg;
 }
 
+unsigned long RadiationWatch::integrationTime()
+{
+  return (historyLength * HISTORY_UNIT * 1000
+          + previousTime - previousHistoryTime);
+}
+
 unsigned long RadiationWatch::duration()
 {
   // Elapsed time of measurement (milliseconds).
@@ -149,7 +155,7 @@ int RadiationWatch::currentRadiationCount() {
 float RadiationWatch::cpm()
 {
   // cpm = uSv x alpha
-  float min = cpmTime();
+  float min = integrationTime() / 60000.0;
   return (min > 0) ? _count / min : 0;
 }
 
@@ -162,6 +168,6 @@ float RadiationWatch::uSvh()
 
 float RadiationWatch::uSvhError()
 {
-  float min = cpmTime();
+  float min = integrationTime() / 60000.0;
   return (min > 0) ? sqrt(_count) / min / kAlpha : 0;
 }

--- a/RadiationWatch.cpp
+++ b/RadiationWatch.cpp
@@ -107,7 +107,7 @@ void RadiationWatch::registerNoiseCallback(void (*callback)(void))
 
 unsigned long RadiationWatch::integrationTime()
 {
-  return (historyLength * HISTORY_UNIT * 1000
+  return (historyLength * HISTORY_UNIT * 1000UL
           + previousTime - previousHistoryTime);
 }
 

--- a/RadiationWatch.cpp
+++ b/RadiationWatch.cpp
@@ -163,8 +163,6 @@ double RadiationWatch::cpm()
   return (min > 0) ? radiationCount() / min : 0;
 }
 
-static const double kAlpha = 53.032;
-
 double RadiationWatch::uSvh()
 {
   return cpm() / kAlpha;

--- a/RadiationWatch.cpp
+++ b/RadiationWatch.cpp
@@ -152,11 +152,15 @@ int RadiationWatch::currentRadiationCount() {
   return currentCount;
 }
 
+unsigned long RadiationWatch::radiationCount() {
+  return _count;
+}
+
 float RadiationWatch::cpm()
 {
   // cpm = uSv x alpha
   float min = integrationTime() / 60000.0;
-  return (min > 0) ? _count / min : 0;
+  return (min > 0) ? radiationCount() / min : 0;
 }
 
 static const float kAlpha = 53.032;
@@ -169,5 +173,5 @@ float RadiationWatch::uSvh()
 float RadiationWatch::uSvhError()
 {
   float min = integrationTime() / 60000.0;
-  return (min > 0) ? sqrt(_count) / min / kAlpha : 0;
+  return (min > 0) ? sqrt(radiationCount()) / min / kAlpha : 0;
 }

--- a/RadiationWatch.cpp
+++ b/RadiationWatch.cpp
@@ -156,22 +156,22 @@ unsigned long RadiationWatch::radiationCount() {
   return _count;
 }
 
-float RadiationWatch::cpm()
+double RadiationWatch::cpm()
 {
   // cpm = uSv x alpha
-  float min = integrationTime() / 60000.0;
+  double min = integrationTime() / 60000.0;
   return (min > 0) ? radiationCount() / min : 0;
 }
 
-static const float kAlpha = 53.032;
+static const double kAlpha = 53.032;
 
-float RadiationWatch::uSvh()
+double RadiationWatch::uSvh()
 {
   return cpm() / kAlpha;
 }
 
-float RadiationWatch::uSvhError()
+double RadiationWatch::uSvhError()
 {
-  float min = integrationTime() / 60000.0;
+  double min = integrationTime() / 60000.0;
   return (min > 0) ? sqrt(radiationCount()) / min / kAlpha : 0;
 }

--- a/RadiationWatch.cpp
+++ b/RadiationWatch.cpp
@@ -17,17 +17,17 @@
 #include <avr/dtostrf.h>
 #endif
 
-int volatile _radiationCount = 0;
-int volatile _noiseCount = 0;
+int volatile RadiationWatch::_radiationCount = 0;
+int volatile RadiationWatch::_noiseCount = 0;
 // Message buffer for output.
 char _msg[60];
 
-void _onRadiationHandler()
+void RadiationWatch::_onRadiationHandler()
 {
   _radiationCount++;
 }
 
-void _onNoiseHandler()
+void RadiationWatch::_onNoiseHandler()
 {
   _noiseCount++;
 }

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -86,5 +86,12 @@ class RadiationWatch
     // User callbacks.
     void (*_radiationCallback)(void);
     void (*_noiseCallback)(void);
+    // radiation count used in interrupt routine
+    static int volatile _radiationCount;
+    // noise count used in interrupt routine
+    static int volatile _noiseCount;
+    // interrupt handler
+    static void _onRadiationHandler();
+    static void _onNoiseHandler();
 };
 #endif

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -53,7 +53,11 @@ class RadiationWatch
      * [ uSvh-uSvhError, uSvh+uSvhError ]. */
     double uSvhError();
     // Dose coefficient (cpm = uSv x alpha)
+#if __cplusplus >= 200704 // constexpr is requiered on C++11
+    static constexpr double kAlpha = 53.032;
+#else
     static const double kAlpha = 53.032;
+#endif
 
     /* Register a function that will be called when a radiation pulse
      * is detected. */

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -47,13 +47,13 @@ class RadiationWatch
      * during the integration time. */
     unsigned long radiationCount();
     // Return the number of radiation count by minute.
-    float cpm();
+    double cpm();
     // Return the radiation dose, exprimed in Sievert (uSv/h).
-    float uSvh();
+    double uSvh();
     /* Return the error of the measurement (uSv/h).
      * The range of precision of the measurement is:
      * [ uSvh-uSvhError, uSvh+uSvhError ]. */
-    float uSvhError();
+    double uSvhError();
 
     /* Register a function that will be called when a radiation pulse
      * is detected. */

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -43,6 +43,9 @@ class RadiationWatch
     /* Return the current radiation count, that is the number of Gamma ray
      * since the last call to loop(), which reset the current count to 0. */
     int currentRadiationCount();
+    /* Return the radiation count, that is the number of Gamma ray occured
+     * during the integration time. */
+    unsigned long radiationCount();
     // Return the number of radiation count by minute.
     float cpm();
     // Return the radiation dose, exprimed in Sievert (uSv/h).

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -53,7 +53,7 @@ class RadiationWatch
      * [ uSvh-uSvhError, uSvh+uSvhError ]. */
     double uSvhError();
     // Dose coefficient (cpm = uSv x alpha)
-    static constexpr double kAlpha = 53.032;
+    static const double kAlpha = 53.032;
 
     /* Register a function that will be called when a radiation pulse
      * is detected. */

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -54,6 +54,8 @@ class RadiationWatch
      * The range of precision of the measurement is:
      * [ uSvh-uSvhError, uSvh+uSvhError ]. */
     double uSvhError();
+    // Dose coefficient (cpm = uSv x alpha)
+    static constexpr double kAlpha = 53.032;
 
     /* Register a function that will be called when a radiation pulse
      * is detected. */

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -38,8 +38,6 @@ class RadiationWatch
     /* Integration time of traced radiation count (in milliseconds),
      * grows gradually to HISTORY_LENGTH * HISTORY_UNIT * 1000. */
     unsigned long integrationTime();
-    // Return the duration of the measurement (ms).
-    unsigned long duration();
     /* Return the current radiation count, that is the number of Gamma ray
      * since the last call to loop(), which reset the current count to 0. */
     int currentRadiationCount();
@@ -64,11 +62,6 @@ class RadiationWatch
      * is detected. */
     void registerNoiseCallback(void (*callback)(void));
 
-    // Get CSV-formatted keys for the status values.
-    char* csvKeys();
-    // Get CSV-formatted current values.
-    char* csvStatus();
-
   protected:
     // History of count rates.
     unsigned int _countHistory[HISTORY_LENGTH];
@@ -80,8 +73,6 @@ class RadiationWatch
     byte historyIndex;
     // Current length of count history
     byte historyLength;
-    // Start time of measurement (milliseconds) used for CSV.
-    unsigned long csvStartTime;
     // Pin settings.
     byte _signPin;
     byte _noisePin;

--- a/RadiationWatch.h
+++ b/RadiationWatch.h
@@ -35,6 +35,9 @@ class RadiationWatch
     void setup();
     void loop();
 
+    /* Integration time of traced radiation count (in milliseconds),
+     * grows gradually to HISTORY_LENGTH * HISTORY_UNIT * 1000. */
+    unsigned long integrationTime();
     // Return the duration of the measurement (ms).
     unsigned long duration();
     /* Return the current radiation count, that is the number of Gamma ray
@@ -74,12 +77,6 @@ class RadiationWatch
     byte historyLength;
     // Start time of measurement (milliseconds) used for CSV.
     unsigned long csvStartTime;
-    // Elapsed time of measurement used for CPM calculation (in minutes).
-    inline float cpmTime()
-    {
-      return (historyLength * HISTORY_UNIT
-              + (previousTime - previousHistoryTime) / 1000.0) / 60.0;
-    }
     // Pin settings.
     byte _signPin;
     byte _noisePin;

--- a/examples/SdCardCsvLogger/SdCardCsvLogger.ino
+++ b/examples/SdCardCsvLogger/SdCardCsvLogger.ino
@@ -10,10 +10,39 @@ Same as SerialCsvLogger, but store the CSV values to an SD card.
 RadiationWatch radiationWatch;
 const byte sdCardPin = 4;
 File dataFile;
+unsigned long csvStartTime;
+
+void csvKeys(Print &print=Serial)
+{
+  // inizialise start time
+  csvStartTime = millis();
+  // Write CSV keys to a print class (default print class is Serial).
+  print.println("time(ms),count,cpm,uSv/h,uSv/hError");
+}
+
+void csvStatus(RadiationWatch radiationWatch, Print &print=Serial)
+{
+  // Write CSV to a print class (default print class is Serial).
+  // time(ms)
+  print.print(millis() - csvStartTime);
+  print.print(',');
+  // count
+  print.print(radiationWatch.radiationCount());
+  print.print(',');
+  // cpm
+  print.print(radiationWatch.cpm(), 3);
+  print.print(',');
+  // uSv/h
+  print.print(radiationWatch.uSvh(), 3);
+  print.print(',');
+  // uSv/hError
+  print.print(radiationWatch.uSvhError(), 3);
+  print.println("");
+}
 
 void onRadiationPulse() {
   // For each radiation write the current values to the SD card in CSV.
-  dataFile.println(radiationWatch.csvStatus());
+  csvStatus(radiationWatch, dataFile);
   dataFile.flush();
 }
 
@@ -32,8 +61,8 @@ void setup()
   }
   radiationWatch.setup();
   // Print the CSV keys and the initial values.
-  dataFile.println(radiationWatch.csvKeys());
-  dataFile.println(radiationWatch.csvStatus());
+  csvKeys(dataFile);
+  csvStatus(radiationWatch, dataFile);
   dataFile.flush();
   // Register the callback.
   radiationWatch.registerRadiationCallback(&onRadiationPulse);

--- a/examples/SerialCsvLogger/SerialCsvLogger.ino
+++ b/examples/SerialCsvLogger/SerialCsvLogger.ino
@@ -7,10 +7,39 @@ the radiation level.
 */
 
 RadiationWatch radiationWatch;
+unsigned long csvStartTime;
+
+void csvKeys(Print &print=Serial)
+{
+  // inizialise start time
+  csvStartTime = millis();
+  // Write CSV keys to a print class (default print class is Serial).
+  print.println("time(ms),count,cpm,uSv/h,uSv/hError");
+}
+
+void csvStatus(RadiationWatch radiationWatch, Print &print=Serial)
+{
+  // Write CSV to a print class (default print class is Serial).
+  // time(ms)
+  print.print(millis() - csvStartTime);
+  print.print(',');
+  // count
+  print.print(radiationWatch.radiationCount());
+  print.print(',');
+  // cpm
+  print.print(radiationWatch.cpm(), 3);
+  print.print(',');
+  // uSv/h
+  print.print(radiationWatch.uSvh(), 3);
+  print.print(',');
+  // uSv/hError
+  print.print(radiationWatch.uSvhError(), 3);
+  print.println("");
+}
 
 void onRadiationPulse() {
   // For each radiation update the values sent to serial in CSV.
-  Serial.println(radiationWatch.csvStatus());
+  csvStatus(radiationWatch);
 }
 
 void setup()
@@ -20,8 +49,8 @@ void setup()
   // Register the callback.
   radiationWatch.registerRadiationCallback(&onRadiationPulse);
   // Print the CSV keys and the initial values.
-  Serial.println(radiationWatch.csvKeys());
-  Serial.println(radiationWatch.csvStatus());
+  csvKeys();
+  csvStatus(radiationWatch);
 }
 
 void loop()


### PR DESCRIPTION
Here is the next bunch of patches, free for discussion and testing. This time some api changes. 

In summary:
- methods to be able to calculate the radiation on none floating platforms
- changed float to double (see commit message)
- removed `duration()`, `csvKeys()`, `csvStatus()` and changed the corresponding examples.

Especially the last point saves RAM and makes the library compatible to more platforms, since `dtostrf.h` is no longer used.

The examples should be compatible with the python script but I changed column 2 from `currentRadiationCount()` to `radiationCount()`, since for the callback, `currentRadiationCount()` is always 0.