### PR TITLE
Enable interrupt

### DIFF
--- a/examples/SerialPrinterEnableInterrupt/SerialPrinterEnableInterrupt.ino
+++ b/examples/SerialPrinterEnableInterrupt/SerialPrinterEnableInterrupt.ino
@@ -1,7 +1,15 @@
 /*
 This example is basically the same as SimpleSerialPrinter but utilize
-the EnableInterrupt library.  EnableInterrupt make pin change
-interrupts available and thus allows to use arbitrary pins.
+the EnableInterrupt library.
+
+The EnableInterrupt library make pin change interrupts available and
+thus allows to use arbitrary pins.
+
+See a list of pins supported here:
+https://github.com/GreyGnome/EnableInterrupt/wiki/Usage#pin--port-bestiary
+
+You can install the library from the Arduino Library Manager:
+http://www.arduinolibraries.info/libraries/enable-interrupt
 */
 
 // EnableInterrupt from https://github.com/GreyGnome/EnableInterrupt

--- a/examples/SerialPrinterEnableInterrupt/SerialPrinterEnableInterrupt.ino
+++ b/examples/SerialPrinterEnableInterrupt/SerialPrinterEnableInterrupt.ino
@@ -1,0 +1,41 @@
+/*
+This example is basically the same as SimpleSerialPrinter but utilize
+the EnableInterrupt library.  EnableInterrupt make pin change
+interrupts available and thus allows to use arbitrary pins.
+*/
+
+// EnableInterrupt from https://github.com/GreyGnome/EnableInterrupt
+// include it before RadiationWatch.h
+#include "EnableInterrupt.h"
+#include "RadiationWatch.h"
+
+// Use any pin as you like
+// Here: signPin = 5, noisePin = 6
+RadiationWatch radiationWatch(5, 6);
+
+void onRadiation()
+{
+  Serial.println("A wild gamma ray appeared");
+  Serial.print(radiationWatch.uSvh());
+  Serial.print(" uSv/h +/- ");
+  Serial.println(radiationWatch.uSvhError());
+}
+
+void onNoise()
+{
+  Serial.println("Argh, noise, please stop moving");
+}
+
+void setup()
+{
+  Serial.begin(9600);
+  radiationWatch.setup();
+  // Register the callbacks.
+  radiationWatch.registerRadiationCallback(&onRadiation);
+  radiationWatch.registerNoiseCallback(&onNoise);
+}
+
+void loop()
+{
+  radiationWatch.loop();
+}

--- a/src/RadiationWatch.cpp
+++ b/src/RadiationWatch.cpp
@@ -12,6 +12,7 @@
  * Tourmal <https://github.com/Toumal>
  * Yoan Tournade <yoan@ytotech.com>
  */
+#define LIBCALL_RADIATIONWATCH
 #include "RadiationWatch.h"
 
 int volatile RadiationWatch::_radiationCount = 0;
@@ -50,8 +51,7 @@ void RadiationWatch::setup()
   previousTime = millis();
   previousHistoryTime = millis();
   // Attach interrupt handlers.
-  attachInterrupt(digitalPinToInterrupt(_signPin), _onRadiationHandler, FALLING);
-  attachInterrupt(digitalPinToInterrupt(_noisePin), _onNoiseHandler, FALLING);
+  setupInterrupt();
 }
 
 void RadiationWatch::loop()

--- a/src/RadiationWatch.h
+++ b/src/RadiationWatch.h
@@ -100,6 +100,17 @@ class RadiationWatch
  * outside of a sketch must define LIBCALL_RADIATIONWATCH to avoid
  * linker error. */
 #ifndef LIBCALL_RADIATIONWATCH
+#ifdef EnableInterrupt_h
+/* EnableInterrupt support: Use pin change interrupts utilizing the
+ * EnableInterrupt library.  This works with arbitrary pins as input
+ * for the Pocket Geiger signals.  In your sketch, EnableInterrupt.h
+ * must be included before this file to enable EnableInterrupt
+ * support. */
+void RadiationWatch::setupInterrupt() {
+  enableInterrupt(_signPin, _onRadiationHandler, FALLING);
+  enableInterrupt(_noisePin, _onNoiseHandler, FALLING);
+}
+#else
 /* Default: Use external interrupts utilizing the attachInterrupt()
  * function from the Arduino IDE.  You must connect the Pocket Geiger
  * signals to an interrupt enabled pin, e.g. pin 2 and 3 on the
@@ -108,6 +119,7 @@ void RadiationWatch::setupInterrupt() {
   attachInterrupt(digitalPinToInterrupt(_signPin), _onRadiationHandler, FALLING);
   attachInterrupt(digitalPinToInterrupt(_noisePin), _onNoiseHandler, FALLING);
 }
+#endif
 #endif // LIBCALL_RADIATIONWATCH
 
 #endif // RadiationWatch_h

--- a/src/RadiationWatch.h
+++ b/src/RadiationWatch.h
@@ -83,6 +83,8 @@ class RadiationWatch
     // User callbacks.
     void (*_radiationCallback)(void);
     void (*_noiseCallback)(void);
+    // function to attach the interrupt handler
+    void setupInterrupt();
     // radiation count used in interrupt routine
     static int volatile _radiationCount;
     // noise count used in interrupt routine
@@ -91,4 +93,21 @@ class RadiationWatch
     static void _onRadiationHandler();
     static void _onNoiseHandler();
 };
-#endif
+
+/* Secure that the setupInterrupt() is only defined and compiled once.
+ * To be able to change the setupInterrupt() during compile time, the
+ * function must be define in the header file.  Every include from
+ * outside of a sketch must define LIBCALL_RADIATIONWATCH to avoid
+ * linker error. */
+#ifndef LIBCALL_RADIATIONWATCH
+/* Default: Use external interrupts utilizing the attachInterrupt()
+ * function from the Arduino IDE.  You must connect the Pocket Geiger
+ * signals to an interrupt enabled pin, e.g. pin 2 and 3 on the
+ * Arduino UNO. */
+void RadiationWatch::setupInterrupt() {
+  attachInterrupt(digitalPinToInterrupt(_signPin), _onRadiationHandler, FALLING);
+  attachInterrupt(digitalPinToInterrupt(_noisePin), _onNoiseHandler, FALLING);
+}
+#endif // LIBCALL_RADIATIONWATCH
+
+#endif // RadiationWatch_h


### PR DESCRIPTION
This is the last big change I had in my pipeline.

It adds optional support for the EnableInterrupt library which enables to use pin change interrupts and thus allows to use arbitrary pins on AVR platforms.

I believe, the PocketGeiger is a good example to use pin change interrupts.

Unfortunately, due to my current lack of an Arduino board, this is untested.

@MonsieurV what do you think about it?