### PR TITLE
Initialize all history related variables in setup()

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RadiationWatch
-version=0.6.0
+version=0.6.1
 author=puuu, thomasaw, Tourmal, Yoan Tournade <yoan@ytotech.com>
 maintainer=Yoan Tournade <yoan@ytotech.com>
 sentence=Arduino driver for Radiation Watch Pocket Geiger sensor

--- a/src/RadiationWatch.cpp
+++ b/src/RadiationWatch.cpp
@@ -47,6 +47,9 @@ void RadiationWatch::setup()
   // Initialize _countHistory[].
   for(int i = 0; i < HISTORY_LENGTH; i++)
     _countHistory[i] = 0;
+  _count = 0;
+  historyIndex = 0;
+  historyLength = 0;
   // Init measurement time.
   previousTime = millis();
   previousHistoryTime = millis();


### PR DESCRIPTION
1) In order to be consistent, the initialization of related variables
should be performed in the same function.

2) Now setup() can be used to reinitialize the RadiationWatch
instance.

Tested, works fine for me.

Would be nice, if you create a new release tag after merging. ;-)